### PR TITLE
Version Parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BUILD_DIR = build
+DOCS_DIR = docs
 DESTDIR = ~/install
 BINARY_NAME = awaken
 
@@ -6,6 +7,10 @@ default: all
 
 clean:
 	$(RM) -r $(BUILD_DIR)
+	$(RM) -r $(DOCS_DIR)
+
+$(DOCS_DIR):
+	doxygen Doxyfile
 
 build:
 	meson $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ awaken - prevents your Mac from going to sleep.
 Usage:
   ./build/awaken [OPTION...]
 
-  -d, —-display-sleep  prevent the display from idle sleeping
-  -s, —-system-sleep   prevent the system from idle sleeping (default: true)
-  -t, —-timeout N      timeout in seconds until the sleep assertion expires
+  -d, --display-sleep  prevent the display from idle sleeping
+  -s, --system-sleep   prevent the system from idle sleeping (default: true)
+  -t, --timeout N      timeout in seconds until the sleep assertion expires
                        (default: 0)
 
  Help options:
-  -h, —-help  print this help
+  -h, --help     print this help
+  -v, --version  print version information
 ```
 
 ## Documentation

--- a/awaken.xcodeproj/xcshareddata/xcschemes/awaken.xcscheme
+++ b/awaken.xcodeproj/xcshareddata/xcschemes/awaken.xcscheme
@@ -56,6 +56,10 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "--version"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-d"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/include/Awaken.hpp
+++ b/include/Awaken.hpp
@@ -41,7 +41,8 @@ public:
     Awaken& operator=(Awaken&&) noexcept;
     
 #pragma mark - Properties
-
+    
+    /// Returns the library version
     static std::string version() noexcept;
     
     /// Returns the tool name used in system logs

--- a/include/Awaken.hpp
+++ b/include/Awaken.hpp
@@ -41,6 +41,8 @@ public:
     Awaken& operator=(Awaken&&) noexcept;
     
 #pragma mark - Properties
+
+    static std::string version() noexcept;
     
     /// Returns the tool name used in system logs
     std::string name() const noexcept;

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -1,0 +1,1 @@
+#define AWAKEN_VERSION "@version@"

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,4 +1,7 @@
 project_headers += files(['Log.hpp', 'Awaken.hpp'])
 
+config_file = configure_file(input: 'config.h.in', output: 'config.h', configuration: config)
+project_headers += config_file
+
 subdir('IOPowerAssertion')
 subdir('Waiter')

--- a/main.cpp
+++ b/main.cpp
@@ -49,9 +49,18 @@ cxxopts::ParseResult parseArguments(int argc, char* argv[])
         ("t,timeout", "timeout in seconds until the sleep assertion expires", cxxopts::value<int64_t>()->default_value("0"), "N")
         ;
         
-        options.add_options("Help") ("h,help", "print this help");
+        options.add_options("Help")
+        ("h,help", "print this help")
+        ("v,version", "print version information")
+        ;
         
         const auto result = options.parse(argc, argv);
+        
+        if(result.count("version"))
+        {
+            std::cout << "Awaken " << Awaken::Awaken::version() << std::endl;
+            exit(EXIT_SUCCESS);
+        }
         
         if(result.count("help"))
         {

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,9 @@
 project('awaken', 'cpp',
-  version : '1.0.0',
+  version : '1.1.0',
   default_options : ['warning_level=3', 'c_std=c11', 'cpp_std=c++17'])
+
+config = configuration_data()
+config.set('version', meson.project_version())
 
 project_sources = []
 project_headers = []

--- a/src/Awaken.cpp
+++ b/src/Awaken.cpp
@@ -37,7 +37,7 @@ using ::Awaken::DefaultLog;
 
 #pragma mark - Life Cycle
 
-Awaken::Awaken::Awaken(std::string name) noexcept
+Awaken::Awaken::Awaken(string name) noexcept
     : _powerAssertion(make_unique<IOPowerAssertion>())
     , _waiter(make_unique<WaiterClass>())
 {
@@ -58,12 +58,12 @@ Awaken::Awaken& Awaken::Awaken::operator=(Awaken&& other) noexcept = default;
 
 #pragma mark - Properties
 
-std::string Awaken::Awaken::version() noexcept
+string Awaken::Awaken::version() noexcept
 {
     return AWAKEN_VERSION;
 }
 
-bool Awaken::Awaken::setTimeout(std::chrono::seconds timeout) noexcept
+bool Awaken::Awaken::setTimeout(chrono::seconds timeout) noexcept
 {
     if(this->isRunning())
     {
@@ -77,12 +77,12 @@ bool Awaken::Awaken::setTimeout(std::chrono::seconds timeout) noexcept
     return true;
 }
 
-std::chrono::seconds Awaken::Awaken::timeout() const noexcept
+chrono::seconds Awaken::Awaken::timeout() const noexcept
 {
     return this->_powerAssertion->timeout;
 }
 
-void Awaken::Awaken::setTimeoutHandler(std::function<void()>&& timeoutHandler) noexcept
+void Awaken::Awaken::setTimeoutHandler(function<void()>&& timeoutHandler) noexcept
 {
     this->_waiter->setTimeoutHandler(move(timeoutHandler));
 }

--- a/src/Awaken.cpp
+++ b/src/Awaken.cpp
@@ -10,7 +10,12 @@
 #include "IOPowerAssertion/IOPowerAssertion.hpp"
 #include "Waiter/Waiter.hpp"
 #include "Log.hpp"
+
+#if __has_include("config.h")
 #include "config.h"
+#else
+#define AWAKEN_VERSION "current"
+#endif
 
 #define USE_DISPATCH_WAITER 0
 #if USE_DISPATCH_WAITER

--- a/src/Awaken.cpp
+++ b/src/Awaken.cpp
@@ -10,6 +10,7 @@
 #include "IOPowerAssertion/IOPowerAssertion.hpp"
 #include "Waiter/Waiter.hpp"
 #include "Log.hpp"
+#include "config.h"
 
 #define USE_DISPATCH_WAITER 0
 #if USE_DISPATCH_WAITER
@@ -51,6 +52,11 @@ Awaken::Awaken::Awaken(Awaken&& other) noexcept
 Awaken::Awaken& Awaken::Awaken::operator=(Awaken&& other) noexcept = default;
 
 #pragma mark - Properties
+
+std::string Awaken::Awaken::version() noexcept
+{
+    return AWAKEN_VERSION;
+}
 
 bool Awaken::Awaken::setTimeout(std::chrono::seconds timeout) noexcept
 {


### PR DESCRIPTION
- added a `config.h.in` that gets rewritten to `config.h` during `meson` builds that simply contains the library version
- added a `--version` launch parameter to print the tool version
- added a `make docs` target to generate the docs