### PR TITLE
Minimum Battery Level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 1.1.0
+- added the `-b` parameter to set a minimum battery level that causes the sleep assertion to expire
+
+## 1.0.0: First Release (2020-05-02)
+This is the first release of the `awaken` utility. The underlying API might still change a lot.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 1.1.0
+- added the `-v` parameter and the `Awaken::version()` property to print version information
 - added the `-b` parameter to set a minimum battery level that causes the sleep assertion to expire
 
 ## 1.0.0: First Release (2020-05-02)

--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ Usage:
   -d, --display-sleep  prevent the display from idle sleeping
   -s, --system-sleep   prevent the system from idle sleeping (default: true)
                          true)
-  -t, --timeout N      timeout in seconds until the sleep assertion expires
-                       (default: 0)
-  -b, --battery-level F  a minimum battery level on devices with a built-in
+  -t, --timeout N        timeout in seconds until the sleep assertion expires
+                         (default: 0)
+  -b, --battery-level N  a minimum battery level on devices with a built-in
                          battery that causes the sleep assertion to expire
-                         (e.g. 0.2 for <= 20% remaining battery) (default: 0.0)
+                         (e.g. 20 for <= 20% remaining battery). Values above 95
+                         are unreliable and depend on the battery health.
+                         (default: 0)
 
  Help options:
   -h, --help     print this help

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ awaken - prevents your Mac from going to sleep.
 Usage:
   ./build/awaken [OPTION...]
 
-  -d, --display-sleep  prevent the display from idle sleeping
-  -s, --system-sleep   prevent the system from idle sleeping (default: true)
+  -d, --display-sleep    prevent the display from idle sleeping
+  -s, --system-sleep     prevent the system from idle sleeping (default:
                          true)
   -t, --timeout N        timeout in seconds until the sleep assertion expires
                          (default: 0)

--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@ Usage:
 
   -d, --display-sleep  prevent the display from idle sleeping
   -s, --system-sleep   prevent the system from idle sleeping (default: true)
+                         true)
   -t, --timeout N      timeout in seconds until the sleep assertion expires
                        (default: 0)
+  -b, --battery-level F  a minimum battery level on devices with a built-in
+                         battery that causes the sleep assertion to expire
+                         (e.g. 0.2 for <= 20% remaining battery) (default: 0.0)
 
  Help options:
   -h, --help     print this help

--- a/awaken.xcodeproj/project.pbxproj
+++ b/awaken.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		DA0079DB24647A0600FD21FE /* IOPowerSource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DA0079D8246479FF00FD21FE /* IOPowerSource.cpp */; };
 		DA4706FF23B4E3B60092676D /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DAC0097823B22238009CC9B2 /* main.cpp */; };
 		DA49C42A23B3CE76002E11A3 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA49C42823B3CE5B002E11A3 /* CoreFoundation.framework */; };
 		DA49C42C23B3CE85002E11A3 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA49C42423B3CE4B002E11A3 /* IOKit.framework */; };
@@ -46,6 +47,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		DA0079D8246479FF00FD21FE /* IOPowerSource.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IOPowerSource.cpp; sourceTree = "<group>"; };
+		DA0079D9246479FF00FD21FE /* IOPowerSource.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = IOPowerSource.hpp; sourceTree = "<group>"; };
 		DA286394245CBF52002D008B /* cxxopts.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cxxopts.hpp; sourceTree = "<group>"; };
 		DA4706FD23B4E3120092676D /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
 		DA49C42423B3CE4B002E11A3 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
@@ -87,6 +90,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		DA0079DC24647A2300FD21FE /* IOPowerSource */ = {
+			isa = PBXGroup;
+			children = (
+				DA0079D9246479FF00FD21FE /* IOPowerSource.hpp */,
+			);
+			path = IOPowerSource;
+			sourceTree = "<group>";
+		};
+		DA0079DD24647A2D00FD21FE /* IOPowerSource */ = {
+			isa = PBXGroup;
+			children = (
+				DA0079D8246479FF00FD21FE /* IOPowerSource.cpp */,
+			);
+			path = IOPowerSource;
+			sourceTree = "<group>";
+		};
 		DA28638E245CBF52002D008B /* vendor */ = {
 			isa = PBXGroup;
 			children = (
@@ -117,6 +136,7 @@
 			isa = PBXGroup;
 			children = (
 				DA6EF2D4245C9125002EBB83 /* Awaken.cpp */,
+				DA0079DD24647A2D00FD21FE /* IOPowerSource */,
 				DA6EF2D5245C9125002EBB83 /* IOPowerAssertion */,
 				DA6EF2D9245C9125002EBB83 /* Waiter */,
 			);
@@ -145,6 +165,7 @@
 			children = (
 				DA6EF2E7245C9125002EBB83 /* Awaken.hpp */,
 				DA6EF2E8245C9125002EBB83 /* Log.hpp */,
+				DA0079DC24647A2300FD21FE /* IOPowerSource */,
 				DA6EF2DE245C9125002EBB83 /* IOPowerAssertion */,
 				DA6EF2E2245C9125002EBB83 /* Waiter */,
 			);
@@ -307,6 +328,7 @@
 				DA6EF2EC245C9125002EBB83 /* ThreadWaiter.cpp in Sources */,
 				DA6EF2EB245C9125002EBB83 /* DispatchWaiter.cpp in Sources */,
 				DA6EF2E9245C9125002EBB83 /* Awaken.cpp in Sources */,
+				DA0079DB24647A0600FD21FE /* IOPowerSource.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/awaken.xcodeproj/project.pbxproj
+++ b/awaken.xcodeproj/project.pbxproj
@@ -280,7 +280,7 @@
 		DAC0096D23B22238009CC9B2 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				CLASSPREFIX = KYA;
+				CLASSPREFIX = "";
 				LastUpgradeCheck = 1140;
 				ORGANIZATIONNAME = "Marcel Dierkes";
 				TargetAttributes = {

--- a/awaken.xcodeproj/xcshareddata/xcschemes/awaken.xcscheme
+++ b/awaken.xcodeproj/xcshareddata/xcschemes/awaken.xcscheme
@@ -56,7 +56,7 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--version"
+            argument = "-b 0.2"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument

--- a/awaken.xcodeproj/xcshareddata/xcschemes/awaken.xcscheme
+++ b/awaken.xcodeproj/xcshareddata/xcschemes/awaken.xcscheme
@@ -56,7 +56,7 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "-b 0.2"
+            argument = "-b 50"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument

--- a/awaken.xcodeproj/xcshareddata/xcschemes/awaken.xcscheme
+++ b/awaken.xcodeproj/xcshareddata/xcschemes/awaken.xcscheme
@@ -53,23 +53,23 @@
       <CommandLineArguments>
          <CommandLineArgument
             argument = "--help"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-b 50"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-d"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-s"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-t 5"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>

--- a/awaken.xcodeproj/xcshareddata/xcschemes/awaken.xcscheme
+++ b/awaken.xcodeproj/xcshareddata/xcschemes/awaken.xcscheme
@@ -56,6 +56,10 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "--version"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-b 50"
             isEnabled = "YES">
          </CommandLineArgument>

--- a/include/Awaken.hpp
+++ b/include/Awaken.hpp
@@ -49,20 +49,6 @@ public:
     /// Returns the tool name used in system logs
     std::string name() const noexcept;
     
-    /// Sets the timeout for the selected power assertions.
-    /// @param timeout A timeout in seconds, if set to 0 or InfiniteTimeout,
-    ///                it will be assumed to be an indefinite timeout.
-    /// @returns true if the timeout could be modified.
-    bool setTimeout(std::chrono::seconds timeout) noexcept;
-    /// The timeout for the selected power assertions.
-    /// A value of 0 (aka InfiniteTimeout) represents
-    /// an indefinite timeout.
-    std::chrono::seconds timeout() const noexcept;
-    
-    /// Sets an optional timeout handler that will be called
-    /// on a private thread when the timeout is reached.
-    void setTimeoutHandler(std::function<void()>&&) noexcept;
-    
     /// Prevents the system from sleeping automatically
     /// due to a lack of user activity if set to true.
     /// @param value prevent system sleep when true
@@ -77,6 +63,44 @@ public:
     bool setPreventUserIdleDisplaySleep(bool value) noexcept;
     /// Prevents the display from dimming automatically if true.
     bool preventUserIdleDisplaySleep() const noexcept;
+    
+#pragma mark - Timeout
+    
+    /// Sets the timeout for the selected power assertions.
+    /// @param timeout A timeout in seconds, if set to 0 or InfiniteTimeout,
+    ///                it will be assumed to be an indefinite timeout.
+    /// @returns true if the timeout could be modified.
+    bool setTimeout(std::chrono::seconds timeout) noexcept;
+    /// The timeout for the selected power assertions.
+    /// A value of 0 (aka InfiniteTimeout) represents
+    /// an indefinite timeout.
+    std::chrono::seconds timeout() const noexcept;
+    
+    /// Sets an optional timeout handler that will be called
+    /// on a private thread when the timeout is reached.
+    void setTimeoutHandler(std::function<void()>&&) noexcept;
+    
+#pragma mark - Minimum Battery Capacity
+    
+    /// Returns true if the current device has a built-in battery.
+    bool hasBattery() const noexcept;
+    
+    /// Set the minimum limit for the battery capacity,
+    /// if this capacity is reached, the sleep assertions
+    /// will be released.
+    /// @param capacity The battery capacity (e.g. 20.0f for 20 % capacity)
+    void setMinimumBatteryCapacity(float capacity) noexcept;
+    
+    /// Returns the minimum battery capacity limit. If the
+    /// current devices reaches this limit, the sleep assertions
+    /// will be released. (e.g. 20.0f for 20 % capacity)
+    /// @note A negative value is returned if the current
+    ///       device does not have a built-in battery.
+    float minimumBatteryCapacity() const noexcept;
+    
+    /// An optional handler that will be called when the battery
+    /// capacity reaches the `minimumBatteryCapacity()`.
+    void setMinimumBatteryCapacityReachedHandler(std::function<void(float)>&&) noexcept;
     
 #pragma mark - Running
     

--- a/include/Awaken.hpp
+++ b/include/Awaken.hpp
@@ -49,6 +49,11 @@ public:
     /// Returns the tool name used in system logs
     std::string name() const noexcept;
     
+    /// @name Power Assertions
+    /// Configures the desired power assertions to
+    /// actually keep the system or display awake.
+    /// @{
+    
     /// Prevents the system from sleeping automatically
     /// due to a lack of user activity if set to true.
     /// @param value prevent system sleep when true
@@ -64,7 +69,13 @@ public:
     /// Prevents the display from dimming automatically if true.
     bool preventUserIdleDisplaySleep() const noexcept;
     
+    /// @}
+    
 #pragma mark - Timeout
+    
+    /// @name Timeout
+    /// Configures the duration of the configured power assertions
+    /// @{
     
     /// Sets the timeout for the selected power assertions.
     /// @param timeout A timeout in seconds, if set to 0 or InfiniteTimeout,
@@ -80,7 +91,16 @@ public:
     /// on a private thread when the timeout is reached.
     void setTimeoutHandler(std::function<void()>&&) noexcept;
     
+    /// @}
+    
 #pragma mark - Minimum Battery Capacity
+    
+    /// @name Minimum Battery Capacity
+    /// Configures a minimum battery capacity threshold
+    /// until power assertions are held.
+    /// @note These properties only apply if the system
+    /// has a built-in battery.
+    /// @{
     
     /// Returns true if the current device has a built-in battery.
     bool hasBattery() const noexcept;
@@ -102,7 +122,13 @@ public:
     /// battery capacity is reached.
     void setMinimumBatteryCapacityReachedHandler(std::function<void(float)>&&) noexcept;
     
+    /// @}
+    
 #pragma mark - Running
+    
+    /// @name Running
+    /// Runs and cancels all configured power assertions.
+    /// @{
     
     /// Returns true if a sleep assertion is currently running
     bool isRunning() const noexcept;
@@ -114,6 +140,8 @@ public:
     
     /// Cancels any sleep assertions.
     void cancel() noexcept;
+    
+    /// @}
     
 private:
     std::unique_ptr<IOPowerAssertion> _powerAssertion;

--- a/include/Awaken.hpp
+++ b/include/Awaken.hpp
@@ -98,6 +98,8 @@ public:
     
     /// An optional handler that will be called when the battery
     /// capacity reaches the `minimumBatteryCapacity()`.
+    /// Any sleep assertions will be cancelled when the minimum
+    /// battery capacity is reached.
     void setMinimumBatteryCapacityReachedHandler(std::function<void(float)>&&) noexcept;
     
 #pragma mark - Running

--- a/include/Awaken.hpp
+++ b/include/Awaken.hpp
@@ -17,6 +17,7 @@
 namespace Awaken
 {
 class IOPowerAssertion;
+class IOPowerSource;
 class Waiter;
 
 /// Represents an infinite timeout duration
@@ -92,6 +93,7 @@ public:
     
 private:
     std::unique_ptr<IOPowerAssertion> _powerAssertion;
+    std::unique_ptr<IOPowerSource> _powerSource;
     std::unique_ptr<Waiter> _waiter;
 };
 

--- a/include/Awaken.hpp
+++ b/include/Awaken.hpp
@@ -94,8 +94,6 @@ public:
     /// Returns the minimum battery capacity limit. If the
     /// current devices reaches this limit, the sleep assertions
     /// will be released. (e.g. 20.0f for 20 % capacity)
-    /// @note A negative value is returned if the current
-    ///       device does not have a built-in battery.
     float minimumBatteryCapacity() const noexcept;
     
     /// An optional handler that will be called when the battery
@@ -119,6 +117,7 @@ private:
     std::unique_ptr<IOPowerAssertion> _powerAssertion;
     std::unique_ptr<IOPowerSource> _powerSource;
     std::unique_ptr<Waiter> _waiter;
+    float _minimumBatteryCapacity;
 };
 
 }

--- a/include/IOPowerSource/IOPowerSource.hpp
+++ b/include/IOPowerSource/IOPowerSource.hpp
@@ -10,6 +10,7 @@
 #define IOPowerSource_hpp
 
 #include <functional>
+#include <optional>
 
 namespace Awaken
 {
@@ -61,7 +62,7 @@ public:
     bool unregisterFromCapacityChanges() noexcept;
     
 private:
-    
+    std::optional<std::function<void()>> _capacityChangeHandler;
 };
 
 }

--- a/include/IOPowerSource/IOPowerSource.hpp
+++ b/include/IOPowerSource/IOPowerSource.hpp
@@ -63,9 +63,8 @@ public:
     
 private:
     std::optional<std::function<void(float)>> _capacityChangeHandler;
-    void* _runLoopSource;
-    
-    static void _batteryCapacityDidChange(void* context);
+    void* _dispatchQueue;
+    int _notificationToken;
 };
 
 }

--- a/include/IOPowerSource/IOPowerSource.hpp
+++ b/include/IOPowerSource/IOPowerSource.hpp
@@ -36,14 +36,14 @@ public:
     IOPowerSource(IOPowerSource&&) = default;
     IOPowerSource& operator=(IOPowerSource&&) = default;
     
-#pragma mark - Properties
+#pragma mark - Battery Capacity
     
     /// Returns true if the current device has a built-in battery.
-    bool isBatteryStatusAvailable() const noexcept;
+    bool hasBattery() const noexcept;
     
     /// Returns the power source battery capacity or
     /// `CapacityUnavailable` if no capacity is available.
-    float batteryCapacity() const noexcept;
+    float capacity() const noexcept;
     
 #pragma mark - Capacity Changes
     

--- a/include/IOPowerSource/IOPowerSource.hpp
+++ b/include/IOPowerSource/IOPowerSource.hpp
@@ -9,10 +9,60 @@
 #ifndef IOPowerSource_hpp
 #define IOPowerSource_hpp
 
+#include <functional>
+
 namespace Awaken
 {
 
-
+/// Represents the device power source with a battery capacity
+/// if available.
+class IOPowerSource
+{
+public:
+    
+    /// A return value representing the unavailability
+    /// of a power source capacity.
+    constexpr static float CapacityUnavailable = -1.0;
+    
+#pragma mark - Life Cycle
+    
+    IOPowerSource() noexcept;
+    ~IOPowerSource() noexcept;
+    
+    IOPowerSource(const IOPowerSource&) = delete;
+    IOPowerSource& operator=(const IOPowerSource&) = delete;
+    
+    IOPowerSource(IOPowerSource&&) = default;
+    IOPowerSource& operator=(IOPowerSource&&) = default;
+    
+#pragma mark - Properties
+    
+    /// Returns true if the current device has a built-in battery.
+    bool isBatteryStatusAvailable() const noexcept;
+    
+    /// Returns the power source battery capacity or
+    /// `CapacityUnavailable` if no capacity is available.
+    float batteryCapacity() const noexcept;
+    
+#pragma mark - Capacity Changes
+    
+    /// An optional handler that will be called when the power source capacity
+    /// changes and `registerForCapacityChanges()` was called.
+    void setCapacityChangeHandler(std::function<void(float)>&&) noexcept;
+    
+    /// Registers the instance to receive power source capacity change
+    /// events using the handler set with `setCapacityChangeHandler()`.
+    /// @returns false if already registered for capacity changes
+    bool registerForCapacityChanges() noexcept;
+    
+    /// Unregisters the instance from receiving power source capacity
+    /// change events.
+    /// @returns false if not registered for capacity changes
+    bool unregisterFromCapacityChanges() noexcept;
+    
+private:
+    
+};
 
 }
 

--- a/include/IOPowerSource/IOPowerSource.hpp
+++ b/include/IOPowerSource/IOPowerSource.hpp
@@ -1,0 +1,19 @@
+//
+//  IOPowerSource.hpp
+//  awaken
+//
+//  Created by Marcel Dierkes on 07.05.20.
+//  Copyright © 2020 Marcel Dierkes. All rights reserved.
+//
+
+#ifndef IOPowerSource_hpp
+#define IOPowerSource_hpp
+
+namespace Awaken
+{
+
+
+
+}
+
+#endif /* IOPowerSource_hpp */

--- a/include/IOPowerSource/IOPowerSource.hpp
+++ b/include/IOPowerSource/IOPowerSource.hpp
@@ -62,7 +62,10 @@ public:
     bool unregisterFromCapacityChanges() noexcept;
     
 private:
-    std::optional<std::function<void()>> _capacityChangeHandler;
+    std::optional<std::function<void(float)>> _capacityChangeHandler;
+    void* _runLoopSource;
+    
+    static void _batteryCapacityDidChange(void* context);
 };
 
 }

--- a/include/IOPowerSource/IOPowerSource.hpp
+++ b/include/IOPowerSource/IOPowerSource.hpp
@@ -1,6 +1,6 @@
 //
 //  IOPowerSource.hpp
-//  awaken
+//  Awaken
 //
 //  Created by Marcel Dierkes on 07.05.20.
 //  Copyright © 2020 Marcel Dierkes. All rights reserved.

--- a/include/IOPowerSource/IOPowerSource.hpp
+++ b/include/IOPowerSource/IOPowerSource.hpp
@@ -62,6 +62,7 @@ public:
     bool unregisterFromCapacityChanges() noexcept;
     
 private:
+    float _capacity;
     std::optional<std::function<void(float)>> _capacityChangeHandler;
     void* _dispatchQueue;
     int _notificationToken;

--- a/include/IOPowerSource/meson.build
+++ b/include/IOPowerSource/meson.build
@@ -1,0 +1,1 @@
+project_headers += files('IOPowerSource.hpp')

--- a/include/meson.build
+++ b/include/meson.build
@@ -4,4 +4,5 @@ config_file = configure_file(input: 'config.h.in', output: 'config.h', configura
 project_headers += config_file
 
 subdir('IOPowerAssertion')
+subdir('IOPowerSource')
 subdir('Waiter')

--- a/main.cpp
+++ b/main.cpp
@@ -23,6 +23,11 @@ void runAwaken(std::chrono::seconds timeout, bool preventDisplaySleep, bool prev
     using namespace std::chrono_literals;
     awaken.setTimeout(timeout);
     
+    awaken.setMinimumBatteryCapacity(97.0f);
+    awaken.setMinimumBatteryCapacityReachedHandler([](float capacity) {
+        printf("Fire.\n");
+    });
+    
     awaken.setTimeoutHandler([]{
         exit(EXIT_SUCCESS);
     });

--- a/main.cpp
+++ b/main.cpp
@@ -47,6 +47,7 @@ cxxopts::ParseResult parseArguments(int argc, char* argv[])
         ("d,display-sleep", "prevent the display from idle sleeping", cxxopts::value<bool>()->default_value("false"))
         ("s,system-sleep", "prevent the system from idle sleeping", cxxopts::value<bool>()->default_value("true"))
         ("t,timeout", "timeout in seconds until the sleep assertion expires", cxxopts::value<int64_t>()->default_value("0"), "N")
+        ("b,battery-level", "a minimum battery level on devices with a built-in battery that causes the sleep assertion to expire (e.g. 0.2 for <= 20% remaining battery)", cxxopts::value<float>()->default_value("0.0"), "F")
         ;
         
         options.add_options("Help")
@@ -105,6 +106,12 @@ int main(int argc, char **argv)
     {
         auto customTimeout = result["timeout"].as<int64_t>();
         timeout = std::chrono::seconds { customTimeout };
+    }
+    
+    if(result.count("battery-level"))
+    {
+        auto batteryLevel = result["battery-level"].as<float>();
+        printf("Expiration Battery Level: %f\n", batteryLevel);
     }
     
     runAwaken(timeout, preventDisplaySleep, preventSystemSleep);

--- a/main.cpp
+++ b/main.cpp
@@ -47,7 +47,7 @@ cxxopts::ParseResult parseArguments(int argc, char* argv[])
         ("d,display-sleep", "prevent the display from idle sleeping", cxxopts::value<bool>()->default_value("false"))
         ("s,system-sleep", "prevent the system from idle sleeping", cxxopts::value<bool>()->default_value("true"))
         ("t,timeout", "timeout in seconds until the sleep assertion expires", cxxopts::value<int64_t>()->default_value("0"), "N")
-        ("b,battery-level", "a minimum battery level on devices with a built-in battery that causes the sleep assertion to expire (e.g. 0.2 for <= 20% remaining battery)", cxxopts::value<float>()->default_value("0.0"), "F")
+        ("b,battery-level", "a minimum battery level on devices with a built-in battery that causes the sleep assertion to expire (e.g. 20 for <= 20% remaining battery). Values above 95 are unreliable and depend on the battery health.", cxxopts::value<uint8_t>()->default_value("0"), "N")
         ;
         
         options.add_options("Help")
@@ -110,8 +110,14 @@ int main(int argc, char **argv)
     
     if(result.count("battery-level"))
     {
-        auto batteryLevel = result["battery-level"].as<float>();
-        printf("Expiration Battery Level: %f\n", batteryLevel);
+        auto batteryLevel = result["battery-level"].as<uint8_t>();
+        if(batteryLevel > 100)
+        {
+            printf("Unsupported battery percentage '%d' provided.\n", batteryLevel);
+            exit(EXIT_FAILURE);
+        }
+        
+        printf("Expiration Battery Level: %d\n", batteryLevel);
     }
     
     runAwaken(timeout, preventDisplaySleep, preventSystemSleep);

--- a/src/Awaken.cpp
+++ b/src/Awaken.cpp
@@ -68,30 +68,6 @@ string Awaken::Awaken::version() noexcept
     return AWAKEN_VERSION;
 }
 
-bool Awaken::Awaken::setTimeout(chrono::seconds timeout) noexcept
-{
-    if(this->isRunning())
-    {
-        os_log(DefaultLog, "The timeout cannot be modified while running.");
-        return false;
-    }
-    
-    this->_waiter->setTimeout(timeout);
-    this->_powerAssertion->timeout = move(timeout);
-    
-    return true;
-}
-
-chrono::seconds Awaken::Awaken::timeout() const noexcept
-{
-    return this->_powerAssertion->timeout;
-}
-
-void Awaken::Awaken::setTimeoutHandler(function<void()>&& timeoutHandler) noexcept
-{
-    this->_waiter->setTimeoutHandler(move(timeoutHandler));
-}
-
 bool Awaken::Awaken::setPreventUserIdleSystemSleep(bool preventUserIdleSystemSleep) noexcept
 {
     if(this->isRunning())
@@ -127,6 +103,46 @@ bool Awaken::Awaken::preventUserIdleDisplaySleep() const noexcept
 {
     return this->_powerAssertion->preventUserIdleDisplaySleep;
 }
+
+#pragma mark - Timeout
+
+bool Awaken::Awaken::setTimeout(chrono::seconds timeout) noexcept
+{
+    if(this->isRunning())
+    {
+        os_log(DefaultLog, "The timeout cannot be modified while running.");
+        return false;
+    }
+    
+    this->_waiter->setTimeout(timeout);
+    this->_powerAssertion->timeout = move(timeout);
+    
+    return true;
+}
+
+chrono::seconds Awaken::Awaken::timeout() const noexcept
+{
+    return this->_powerAssertion->timeout;
+}
+
+void Awaken::Awaken::setTimeoutHandler(function<void()>&& timeoutHandler) noexcept
+{
+    this->_waiter->setTimeoutHandler(move(timeoutHandler));
+}
+
+#pragma mark - Minimum Battery Capacity
+
+bool Awaken::Awaken::hasBattery() const noexcept
+{ return false; }
+
+void Awaken::Awaken::setMinimumBatteryCapacity(float capacity) noexcept
+{}
+
+float Awaken::Awaken::minimumBatteryCapacity() const noexcept
+{ return IOPowerSource::CapacityUnavailable; }
+
+void Awaken::Awaken::setMinimumBatteryCapacityReachedHandler(std::function<void(float)>&& handler) noexcept
+{}
 
 #pragma mark - Running
 

--- a/src/Awaken.cpp
+++ b/src/Awaken.cpp
@@ -44,6 +44,14 @@ Awaken::Awaken::Awaken(string name) noexcept
     , _waiter(make_unique<WaiterClass>())
 {
     this->_powerAssertion->name = name;
+    
+    this->_powerSource->registerForCapacityChanges();
+    float cap = this->_powerSource->capacity();
+    bool is = this->_powerSource->hasBattery();
+    float cap2 = this->_powerSource->capacity();
+    this->_powerSource->setCapacityChangeHandler([](float capacity) {
+        os_log(DefaultLog, "Capacity changed %{public}.00f", capacity);
+    });
 }
 
 Awaken::Awaken::Awaken() noexcept : Awaken::Awaken::Awaken("Awaken") {};

--- a/src/Awaken.cpp
+++ b/src/Awaken.cpp
@@ -21,16 +21,10 @@
 #define USE_DISPATCH_WAITER 0
 #if USE_DISPATCH_WAITER
 #include "Waiter/DispatchWaiter.hpp"
-namespace Awaken
-{
-using WaiterClass = DispatchWaiter;
-}
+namespace Awaken { using WaiterClass = DispatchWaiter; }
 #else
 #include "Waiter/ThreadWaiter.hpp"
-namespace Awaken
-{
-using WaiterClass = ThreadWaiter;
-}
+namespace Awaken { using WaiterClass = ThreadWaiter; }
 #endif
 
 using namespace std;
@@ -60,6 +54,7 @@ Awaken::Awaken::~Awaken() noexcept = default;
 
 Awaken::Awaken::Awaken(Awaken&& other) noexcept
     : _powerAssertion(move(other._powerAssertion))
+    , _powerSource(move(other._powerSource))
     , _waiter(move(other._waiter))
 {
 }

--- a/src/Awaken.cpp
+++ b/src/Awaken.cpp
@@ -8,6 +8,7 @@
 
 #include "Awaken.hpp"
 #include "IOPowerAssertion/IOPowerAssertion.hpp"
+#include "IOPowerSource/IOPowerSource.hpp"
 #include "Waiter/Waiter.hpp"
 #include "Log.hpp"
 
@@ -39,6 +40,7 @@ using ::Awaken::DefaultLog;
 
 Awaken::Awaken::Awaken(string name) noexcept
     : _powerAssertion(make_unique<IOPowerAssertion>())
+    , _powerSource(make_unique<IOPowerSource>())
     , _waiter(make_unique<WaiterClass>())
 {
     this->_powerAssertion->name = name;

--- a/src/Awaken.cpp
+++ b/src/Awaken.cpp
@@ -131,6 +131,7 @@ bool Awaken::Awaken::hasBattery() const noexcept
 
 void Awaken::Awaken::setMinimumBatteryCapacity(float capacity) noexcept
 {
+    os_log(DefaultLog, "Setting minimum battery capacity to %{public}.00f…", capacity);
     this->_minimumBatteryCapacity = capacity;
 }
 

--- a/src/IOPowerSource/IOPowerSource.cpp
+++ b/src/IOPowerSource/IOPowerSource.cpp
@@ -1,0 +1,15 @@
+//
+//  IOPowerSource.cpp
+//  awaken
+//
+//  Created by Marcel Dierkes on 07.05.20.
+//  Copyright © 2020 Marcel Dierkes. All rights reserved.
+//
+
+#include "IOPowerSource/IOPowerSource.hpp"
+#include <CoreFoundation/CoreFoundation.h>
+#import <IOKit/ps/IOPowerSources.h>
+#include "Log.hpp"
+
+using namespace std;
+using namespace Awaken;

--- a/src/IOPowerSource/IOPowerSource.cpp
+++ b/src/IOPowerSource/IOPowerSource.cpp
@@ -1,6 +1,6 @@
 //
 //  IOPowerSource.cpp
-//  awaken
+//  Awaken
 //
 //  Created by Marcel Dierkes on 07.05.20.
 //  Copyright © 2020 Marcel Dierkes. All rights reserved.

--- a/src/IOPowerSource/IOPowerSource.cpp
+++ b/src/IOPowerSource/IOPowerSource.cpp
@@ -157,7 +157,7 @@ bool IOPowerSource::registerForCapacityChanges() noexcept
         }
     };
     
-    notify_register_dispatch(kIOPSTimeRemainingNotificationKey, &this->_notificationToken, dispatchQueue, ^(int token) {
+    notify_register_dispatch(kIOPSTimeRemainingNotificationKey, &this->_notificationToken, dispatchQueue, ^(int) {
         capacityDidChange();
     });
     

--- a/src/IOPowerSource/IOPowerSource.cpp
+++ b/src/IOPowerSource/IOPowerSource.cpp
@@ -58,7 +58,7 @@ static auto CopyPowerSourceDescription() -> optional<CFDictionaryRef>
     CFRelease(sourcesList);
     CFRelease(powerSources);
     
-    if(powerSource == NULL) { return nullopt; }
+    if(powerSource == nullptr) { return nullopt; }
     return powerSource;
 }
 
@@ -74,7 +74,7 @@ bool IOPowerSource::hasBattery() const noexcept
         const auto internalBatteryTypeKey = CFSTR(kIOPSInternalBatteryType);
         
         auto batteryType = static_cast<CFStringRef>(CFDictionaryGetValue(*powerSourceDescription, key));
-        if(batteryType == NULL)
+        if(batteryType == nullptr)
         {
             CFRelease(*powerSourceDescription);
             return false;

--- a/src/IOPowerSource/IOPowerSource.cpp
+++ b/src/IOPowerSource/IOPowerSource.cpp
@@ -132,6 +132,8 @@ bool IOPowerSource::registerForCapacityChanges() noexcept
         return false;
     }
     
+    os_log(DefaultLog, "Registering for battery capacity changes…");
+    
     const auto dispatchQueue = dispatch_queue_create("info.marcel-dierkes.Awaken.IOPowerSourceQueue",
                                                      DISPATCH_QUEUE_SERIAL);
     this->_dispatchQueue = dispatchQueue;
@@ -180,6 +182,8 @@ bool IOPowerSource::unregisterFromCapacityChanges() noexcept
     const auto dispatchQueue = static_cast<dispatch_queue_t>(this->_dispatchQueue);
     dispatch_release(dispatchQueue);
     this->_dispatchQueue = nullptr;
+    
+    os_log(DefaultLog, "Unregistered from battery capacity changes.");
     
     return true;
 }

--- a/src/IOPowerSource/IOPowerSource.cpp
+++ b/src/IOPowerSource/IOPowerSource.cpp
@@ -13,3 +13,123 @@
 
 using namespace std;
 using namespace Awaken;
+
+#pragma mark - Life Cycle
+
+IOPowerSource::IOPowerSource() noexcept
+    : _capacityChangeHandler(nullopt)
+{
+}
+
+IOPowerSource::~IOPowerSource() noexcept
+{
+}
+
+
+// Reference Sources for KYABatteryStatus.m
+
+//const CGFloat KYABatteryStatusUnavailable = -1.0;
+//
+//static void KYABatteryStatusChangeHandler(void *context);
+//
+//@interface KYABatteryStatus ()
+//@property (nonatomic, nullable) CFRunLoopSourceRef runLoopSource;
+//@end
+//
+//@implementation KYABatteryStatus
+//
+//- (void)dealloc
+//{
+//    [self unregisterFromCapacityChanges];
+//}
+//
+//- (BOOL)isBatteryStatusAvailable
+//{
+//    KYA_AUTO powerSourceInfos = [self powerSourceInfos];
+//    if(powerSourceInfos == nil)
+//    {
+//        return NO;
+//    }
+//
+//    KYA_AUTO key = [NSString stringWithUTF8String:kIOPSTypeKey];
+//    KYA_AUTO internalBatteryTypeKey = [NSString stringWithUTF8String:kIOPSInternalBatteryType];
+//    NSString *batteryType = powerSourceInfos[key];
+//    return [batteryType isEqualToString:internalBatteryTypeKey];
+//}
+//
+//- (CGFloat)currentCapacity
+//{
+//    KYA_AUTO powerSourceInfos = [self powerSourceInfos];
+//    if(powerSourceInfos == nil)
+//    {
+//        return KYABatteryStatusUnavailable;
+//    }
+//
+//    KYA_AUTO key = [NSString stringWithUTF8String:kIOPSCurrentCapacityKey];
+//    NSNumber *capacity = powerSourceInfos[key];
+//    if(capacity == nil)
+//    {
+//        return KYABatteryStatusUnavailable;
+//    }
+//
+//    return capacity.floatValue;
+//}
+//
+//- (nullable NSDictionary *)powerSourceInfos
+//{
+//    KYA_AUTO blob = IOPSCopyPowerSourcesInfo();
+//    KYA_AUTO sourcesList = IOPSCopyPowerSourcesList(blob);
+//    CFRelease(blob);
+//
+//    if(CFArrayGetCount(sourcesList) == 0) {
+//        CFRelease(sourcesList);
+//        return nil;
+//    }
+//
+//    KYA_AUTO powerSource = IOPSGetPowerSourceDescription(blob, CFArrayGetValueAtIndex(sourcesList, 0));
+//    CFRetain(powerSource);
+//    CFRelease(sourcesList);
+//
+//    CFAutorelease(powerSource);
+//    return (__bridge NSDictionary *)powerSource;
+//}
+//
+//#pragma mark - Capacity Change Handler
+//
+//- (void)registerForCapacityChangesIfNeeded
+//{
+//    if(self.runLoopSource)
+//    {
+//        return;
+//    }
+//
+//    KYA_AUTO runLoopSource = IOPSNotificationCreateRunLoopSource(KYABatteryStatusChangeHandler, (__bridge void *)self);
+//    CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, kCFRunLoopDefaultMode);
+//
+//    self.runLoopSource = runLoopSource;
+//    CFRelease(runLoopSource);
+//}
+//
+//- (void)unregisterFromCapacityChanges
+//{
+//    if(!self.runLoopSource)
+//    {
+//        return;
+//    }
+//
+//    CFRunLoopRemoveSource(CFRunLoopGetCurrent(), self.runLoopSource, kCFRunLoopDefaultMode);
+//    self.runLoopSource = nil;
+//}
+//
+//@end
+//
+//#pragma mark - KYABatteryStatusChangeHandler
+//
+//static void KYABatteryStatusChangeHandler(void *context)
+//{
+//    KYA_AUTO batteryStatus = (__bridge KYABatteryStatus *)context;
+//    if(batteryStatus.capacityChangeHandler)
+//    {
+//        batteryStatus.capacityChangeHandler(batteryStatus.currentCapacity);
+//    }
+//}

--- a/src/IOPowerSource/meson.build
+++ b/src/IOPowerSource/meson.build
@@ -1,0 +1,1 @@
+project_sources += files('IOPowerSource.cpp')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,4 +1,5 @@
 project_sources += files('Awaken.cpp')
 
 subdir('IOPowerAssertion')
+subdir('IOPowerSource')
 subdir('Waiter')


### PR DESCRIPTION
- added `--version` parameter to return the current tool version
- added `--battery-level` parameter to set a minimum battery level; when this level is reached, sleep assertions will be cancelled
- header groups for better Doxygen support